### PR TITLE
Add options to shape how payloads are added to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,25 @@ productsActions("fail", {test: "error"})
 //   payload: { test: "error" }
 // }
 ```
-#### customSuccessPayload (Function, recieves payload)
-Applies a custom payload directly onto successful actions.
+#### customRequestPayload (Function, receives payload)
+Applies a custom payload directly to the request action.
+Useful if you want to remove the payload variable name around your payload,
+or if you want to do some last minute tweaks to your payload.
+```js
+const productsActions = reshort("Products", {
+  customRequestPayload: payload => payload
+});
+
+productsActions("request", {test: 123});
+// {
+//    type: "GET_PRODUCTS",
+//    test: 123
+// }
+```
+
+
+#### customSuccessPayload (Function, receives payload)
+Applies a custom payload directly to the successful action.
 Useful if you want to remove the payload variable name around your payload,
 or if you want to do some last minute tweaks to your payload.
 ```js
@@ -161,7 +178,7 @@ productsActions("success", {test: 123});
 // }
 ```
 
-#### customFailurePayload (Function, recieves payload)
+#### customFailurePayload (Function, receives payload)
 Applies a custom payload directly onto the fail action.
 Useful if you want to remove the payload variable name around your payload,
 or if you want to do some last minute tweaks to your payload.

--- a/README.md
+++ b/README.md
@@ -149,12 +149,14 @@ productsActions("fail", {test: "error"})
 Applies a custom payload directly onto successful actions.
 Useful if you want to remove the payload variable name around your payload,
 or if you want to do some last minute tweaks to your payload.
-```
+```js
 const productsActions = reshort("Products", {
   customSuccessPayload: (payload) => payload
 });
+
+productsActions("success", {test: 123});
 // {
-//    type: "GET_PRODUCTS_SUCCESS",
+//    type: "GET_PRODUCTS_SUCCESSFUL",
 //    test: 123
 // }
 ```
@@ -163,13 +165,15 @@ const productsActions = reshort("Products", {
 Applies a custom payload directly onto the fail action.
 Useful if you want to remove the payload variable name around your payload,
 or if you want to do some last minute tweaks to your payload.
-```
+```js
 const productsActions = reshort("Products", {
   customFailurePayload: (payload) => payload
 });
+
+productsActions("fail", {test: "error"})
 // {
 //    type: "GET_PRODUCTS_FAILURE",
-//    test: 123
+//    test: "error"
 // }
 ```
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,33 @@ productsActions("fail", {test: "error"})
 //   payload: { test: "error" }
 // }
 ```
+#### customSuccessPayload (Function, recieves payload)
+Applies a custom payload directly onto successful actions.
+Useful if you want to remove the payload variable name around your payload,
+or if you want to do some last minute tweaks to your payload.
+```
+const productsActions = reshort("Products", {
+  customSuccessPayload: (payload) => payload
+});
+// {
+//    type: "GET_PRODUCTS_SUCCESS",
+//    test: 123
+// }
+```
+
+#### customFailurePayload (Function, recieves payload)
+Applies a custom payload directly onto the fail action.
+Useful if you want to remove the payload variable name around your payload,
+or if you want to do some last minute tweaks to your payload.
+```
+const productsActions = reshort("Products", {
+  customFailurePayload: (payload) => payload
+});
+// {
+//    type: "GET_PRODUCTS_FAILURE",
+//    test: 123
+// }
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "test": "jest",
+    "test-watch": "jest --watch",
     "coverage": "npm test -- --coverage",
     "postcoverage": "opn coverage/lcov-report/index.html",
     "lint": "eslint . --fix",

--- a/src/makeCompleteAction.js
+++ b/src/makeCompleteAction.js
@@ -1,10 +1,10 @@
 import { upperCase, isEmpty } from "lodash";
 
-const hasPrefixOrSuffix = (options, property) =>
+const checkIfOptionExists = (options, property) =>
   !!(options && options[property]) && options[property];
 
 const mountRequestConstant = (name, options) => {
-  if (hasPrefixOrSuffix(options, "prefix")) {
+  if (checkIfOptionExists(options, "prefix")) {
     const { prefix } = options;
 
     return `${prefix}_${upperCase(name)}`;
@@ -15,8 +15,8 @@ const mountRequestConstant = (name, options) => {
 
 const mountSuccessOrFailureConstants = (name, options, suffix, constant) => {
   if (
-    hasPrefixOrSuffix(options, "prefix") &&
-    !hasPrefixOrSuffix(options, suffix)
+    checkIfOptionExists(options, "prefix") &&
+    !checkIfOptionExists(options, suffix)
   ) {
     const { prefix } = options;
 
@@ -24,8 +24,8 @@ const mountSuccessOrFailureConstants = (name, options, suffix, constant) => {
   }
 
   if (
-    hasPrefixOrSuffix(options, "prefix") &&
-    hasPrefixOrSuffix(options, suffix)
+    checkIfOptionExists(options, "prefix") &&
+    checkIfOptionExists(options, suffix)
   ) {
     const { prefix } = options;
     const optionsSuffix = options[suffix];
@@ -34,8 +34,8 @@ const mountSuccessOrFailureConstants = (name, options, suffix, constant) => {
   }
 
   if (
-    !hasPrefixOrSuffix(options, "prefix") &&
-    hasPrefixOrSuffix(options, suffix)
+    !checkIfOptionExists(options, "prefix") &&
+    checkIfOptionExists(options, suffix)
   ) {
     const optionsSuffix = options[suffix];
 
@@ -70,12 +70,16 @@ const mountRequest = (name, options) => (requestType, payload) => {
 
   const typesOfActions = {
     request: () => {
-      if (options && options.customSuccessPayload) {
+      if (checkIfOptionExists(options, "customRequestPayload")) {
+        if (typeof options.customRequestPayload !== "function") {
+          throw new Error("options.customRequestPayload should be a function.");
+        }
+
         return Object.assign(
           {
             type: mountConstant(name, "request", options)
           },
-          payload
+          options.customRequestPayload(payload)
         );
       }
 
@@ -86,12 +90,16 @@ const mountRequest = (name, options) => (requestType, payload) => {
     },
 
     success: () => {
-      if (options && options.customSuccessPayload) {
+      if (checkIfOptionExists(options, "customSuccessPayload")) {
+        if (typeof options.customSuccessPayload !== "function") {
+          throw new Error("options.customSuccessPayload should be a function.");
+        }
+
         return Object.assign(
           {
             type: mountConstant(name, "success", options)
           },
-          payload
+          options.customSuccessPayload(payload)
         );
       }
 
@@ -102,12 +110,16 @@ const mountRequest = (name, options) => (requestType, payload) => {
     },
 
     fail: () => {
-      if (options && options.customFailurePayload) {
+      if (checkIfOptionExists(options, "customFailurePayload")) {
+        if (typeof options.customFailurePayload !== "function") {
+          throw new Error("options.customFailurePayload should be a function.");
+        }
+
         return Object.assign(
           {
             type: mountConstant(name, "fail", options)
           },
-          payload
+          options.customFailurePayload(payload)
         );
       }
       return {

--- a/src/makeCompleteAction.js
+++ b/src/makeCompleteAction.js
@@ -69,19 +69,58 @@ const mountRequest = (name, options) => (requestType, payload) => {
     throw new Error("The request type name should be a string.");
 
   const typesOfActions = {
-    request: () => ({
-      type: mountConstant(name, "request", options),
-      payload
-    }),
-    success: () => ({
-      type: mountConstant(name, "success", options),
-      payload
-    }),
-    fail: () => ({
-      type: mountConstant(name, "fail", options),
-      payload
-    })
+    request: () => {
+      if (options && options.customSuccessPayload) {
+        return Object.assign(
+          {
+            type: mountConstant(name, "request", options)
+          },
+          payload
+        );
+      }
+
+      return {
+        type: mountConstant(name, "request", options),
+        payload
+      };
+    },
+
+    success: () => {
+      if (options && options.customSuccessPayload) {
+        return Object.assign(
+          {
+            type: mountConstant(name, "success", options)
+          },
+          payload
+        );
+      }
+
+      return {
+        type: mountConstant(name, "success", options),
+        payload
+      };
+    },
+
+    fail: () => {
+      if (options && options.customFailurePayload) {
+        return Object.assign(
+          {
+            type: mountConstant(name, "fail", options)
+          },
+          payload
+        );
+      }
+      return {
+        type: mountConstant(name, "fail", options),
+        payload
+      };
+    }
   };
+
+  if (options && options.customPayload) {
+    typesOfActions.request = Object.assign(typesOfActions.request, payload);
+    typesOfActions.request = Object.assign(typesOfActions.request, payload);
+  }
 
   return typesOfActions[requestType]();
 };

--- a/src/makeCompleteAction.js
+++ b/src/makeCompleteAction.js
@@ -117,11 +117,6 @@ const mountRequest = (name, options) => (requestType, payload) => {
     }
   };
 
-  if (options && options.customPayload) {
-    typesOfActions.request = Object.assign(typesOfActions.request, payload);
-    typesOfActions.request = Object.assign(typesOfActions.request, payload);
-  }
-
   return typesOfActions[requestType]();
 };
 

--- a/test/makeCompleteAction.test.js
+++ b/test/makeCompleteAction.test.js
@@ -227,8 +227,7 @@ describe("makeCompleteAction", () => {
 
       it("should return a success action with a custom payload", () => {
         const action = makeCompleteAction("Products", {
-          customSuccessPayload: customPayload,
-          payload: { test: 123 }
+          customSuccessPayload: customPayload
         });
 
         expect(action("success", { test: 123 })).toEqual({

--- a/test/makeCompleteAction.test.js
+++ b/test/makeCompleteAction.test.js
@@ -162,82 +162,180 @@ describe("makeCompleteAction", () => {
     });
   });
 
-  describe("with customSuccessPayload option", () => {
-    const customSuccessPayload = payload => payload;
+  describe("with custom payload options", () => {
+    const customPayload = payload => payload;
 
-    it("should return a request action with a custom payload", () => {
-      const action = makeCompleteAction("Products", {
-        customSuccessPayload
+    describe("when given a customRequestPayload option", () => {
+      it("should throw an error if the customRequestPayload is not a function", () => {
+        const action = makeCompleteAction("products", {
+          customRequestPayload: "not a function"
+        });
+
+        expect(() => action("request", { test: 123 })).toThrow(
+          "options.customRequestPayload should be a function."
+        );
       });
 
-      expect(action("request", { test: 123 })).toEqual({
-        type: "GET_PRODUCTS",
-        test: 123
-      });
-    });
+      it("should return a request action with a custom payload", () => {
+        const action = makeCompleteAction("Products", {
+          customRequestPayload: customPayload
+        });
 
-    it("should return a success action with a custom payload", () => {
-      const action = makeCompleteAction("Products", {
-        customSuccessPayload,
-        payload: { test: 123 }
-      });
-
-      expect(action("success", { test: 123 })).toEqual({
-        type: "GET_PRODUCTS_SUCCESSFUL",
-        test: 123
-      });
-    });
-
-    it("should return a fail action with a regular payload", () => {
-      const action = makeCompleteAction("products", {
-        customSuccessPayload,
-        payload: { test: 123 }
-      });
-
-      expect(action("fail", { test: 123 })).toEqual({
-        type: "GET_PRODUCTS_FAILURE",
-        payload: {
+        expect(action("request", { test: 123 })).toEqual({
+          type: "GET_PRODUCTS",
           test: 123
-        }
+        });
+      });
+
+      it("should return a default payload for the success action", () => {
+        const action = makeCompleteAction("Products", {
+          customRequestPayload: customPayload
+        });
+
+        expect(action("success", { test: 123 })).toEqual({
+          type: "GET_PRODUCTS_SUCCESSFUL",
+          payload: {
+            test: 123
+          }
+        });
+      });
+
+      it("should return a default payload for the failure action", () => {
+        const action = makeCompleteAction("Products", {
+          customRequestPayload: customPayload
+        });
+
+        expect(action("fail", { test: 123 })).toEqual({
+          type: "GET_PRODUCTS_FAILURE",
+          payload: {
+            test: 123
+          }
+        });
       });
     });
-  });
 
-  describe("with customFailurePayload option", () => {
-    const customFailurePayload = payload => payload;
+    describe("when passed a customSuccessPayload", () => {
+      it("should throw an error if the customSuccessPayload is not a function", () => {
+        const action = makeCompleteAction("products", {
+          customSuccessPayload: "not a function"
+        });
 
-    it("should return a request action with a regular payload", () => {
-      const action = makeCompleteAction("Products", {
-        customFailurePayload,
-        payload: { test: 123 }
+        expect(() => action("success", { test: 123 })).toThrow(
+          "options.customSuccessPayload should be a function."
+        );
       });
 
-      expect(action("request")).toEqual({ type: "GET_PRODUCTS" });
-    });
+      it("should return a success action with a custom payload", () => {
+        const action = makeCompleteAction("Products", {
+          customSuccessPayload: customPayload,
+          payload: { test: 123 }
+        });
 
-    it("should return a success action with a regular payload", () => {
-      const action = makeCompleteAction("Products", {
-        customFailurePayload,
-        payload: { test: 123 }
-      });
-
-      expect(action("success", { test: 123 })).toEqual({
-        type: "GET_PRODUCTS_SUCCESSFUL",
-        payload: {
+        expect(action("success", { test: 123 })).toEqual({
+          type: "GET_PRODUCTS_SUCCESSFUL",
           test: 123
-        }
+        });
+      });
+
+      it("should return a default payload for the request action", () => {
+        const action = makeCompleteAction("Products", {
+          customSuccessPayload: customPayload
+        });
+
+        expect(action("request", { test: 123 })).toEqual({
+          type: "GET_PRODUCTS",
+          payload: {
+            test: 123
+          }
+        });
+      });
+
+      it("should return a default payload for the failure action", () => {
+        const action = makeCompleteAction("Products", {
+          customSuccessPayload: customPayload
+        });
+
+        expect(action("fail", { test: 123 })).toEqual({
+          type: "GET_PRODUCTS_FAILURE",
+          payload: {
+            test: 123
+          }
+        });
       });
     });
 
-    it("should return a fail action with a regular payload", () => {
-      const action = makeCompleteAction("products", {
-        customFailurePayload,
-        payload: { test: 123 }
+    describe("when passed a customFailurePayload option", () => {
+      it("should throw an error if the customFailurePayload is not a function", () => {
+        const action = makeCompleteAction("products", {
+          customFailurePayload: "not a function"
+        });
+
+        expect(() => action("fail", { test: 123 })).toThrow(
+          "options.customFailurePayload should be a function."
+        );
       });
 
-      expect(action("fail", { test: 123 })).toEqual({
-        type: "GET_PRODUCTS_FAILURE",
-        test: 123
+      it("should return a failure action with a custom payload", () => {
+        const action = makeCompleteAction("Products", {
+          customFailurePayload: customPayload,
+          payload: { test: "error" }
+        });
+
+        expect(action("fail", { test: "error" })).toEqual({
+          type: "GET_PRODUCTS_FAILURE",
+          test: "error"
+        });
+      });
+
+      it("should return a default payload for the request action", () => {
+        const action = makeCompleteAction("Products", {
+          customFailurePayload: customPayload
+        });
+
+        expect(action("request", { test: 123 })).toEqual({
+          type: "GET_PRODUCTS",
+          payload: {
+            test: 123
+          }
+        });
+      });
+
+      it("should return a default payload for the success action", () => {
+        const action = makeCompleteAction("Products", {
+          customFailurePayload: customPayload
+        });
+
+        expect(action("success", { test: 123 })).toEqual({
+          type: "GET_PRODUCTS_SUCCESSFUL",
+          payload: {
+            test: 123
+          }
+        });
+      });
+    });
+
+    describe("when passed all three customPayload options", () => {
+      it("should return custom payloads for all request, success and failure actions", () => {
+        const action = makeCompleteAction("Products", {
+          customRequestPayload: customPayload,
+          customSuccessPayload: customPayload,
+          customFailurePayload: customPayload
+        });
+
+        expect(action("request", { test: 123 })).toEqual({
+          type: "GET_PRODUCTS",
+          test: 123
+        });
+
+        expect(action("success", { test: 123 })).toEqual({
+          type: "GET_PRODUCTS_SUCCESSFUL",
+          test: 123
+        });
+
+        expect(action("fail", { test: "error" })).toEqual({
+          type: "GET_PRODUCTS_FAILURE",
+          test: "error"
+        });
       });
     });
   });

--- a/test/makeCompleteAction.test.js
+++ b/test/makeCompleteAction.test.js
@@ -161,4 +161,84 @@ describe("makeCompleteAction", () => {
       });
     });
   });
+
+  describe("with customSuccessPayload option", () => {
+    const customSuccessPayload = payload => payload;
+
+    it("should return a request action with a custom payload", () => {
+      const action = makeCompleteAction("Products", {
+        customSuccessPayload
+      });
+
+      expect(action("request", { test: 123 })).toEqual({
+        type: "GET_PRODUCTS",
+        test: 123
+      });
+    });
+
+    it("should return a success action with a custom payload", () => {
+      const action = makeCompleteAction("Products", {
+        customSuccessPayload,
+        payload: { test: 123 }
+      });
+
+      expect(action("success", { test: 123 })).toEqual({
+        type: "GET_PRODUCTS_SUCCESSFUL",
+        test: 123
+      });
+    });
+
+    it("should return a fail action with a regular payload", () => {
+      const action = makeCompleteAction("products", {
+        customSuccessPayload,
+        payload: { test: 123 }
+      });
+
+      expect(action("fail", { test: 123 })).toEqual({
+        type: "GET_PRODUCTS_FAILURE",
+        payload: {
+          test: 123
+        }
+      });
+    });
+  });
+
+  describe("with customFailurePayload option", () => {
+    const customFailurePayload = payload => payload;
+
+    it("should return a request action with a regular payload", () => {
+      const action = makeCompleteAction("Products", {
+        customFailurePayload,
+        payload: { test: 123 }
+      });
+
+      expect(action("request")).toEqual({ type: "GET_PRODUCTS" });
+    });
+
+    it("should return a success action with a regular payload", () => {
+      const action = makeCompleteAction("Products", {
+        customFailurePayload,
+        payload: { test: 123 }
+      });
+
+      expect(action("success", { test: 123 })).toEqual({
+        type: "GET_PRODUCTS_SUCCESSFUL",
+        payload: {
+          test: 123
+        }
+      });
+    });
+
+    it("should return a fail action with a regular payload", () => {
+      const action = makeCompleteAction("products", {
+        customFailurePayload,
+        payload: { test: 123 }
+      });
+
+      expect(action("fail", { test: 123 })).toEqual({
+        type: "GET_PRODUCTS_FAILURE",
+        test: 123
+      });
+    });
+  });
 });


### PR DESCRIPTION
First of all, thank you for your hard work!

I want to use reshort, but I wanted to be able to control how payloads looked in actions. I don't like the convention of dumping any information into a `payload` variable, and would prefer to explicitly set what I want to store directly on the actions.

I have created options.customRequestPayload, options.customSuccessPayload and options.customFailurePayload, which are all methods which take the payload we pass into the action. We get a chance to tweak the payload as we wish, and return them. The entries inside the payload object then get applied directly to the action, rather than using a payload object.